### PR TITLE
set a view create as same as saml_post

### DIFF
--- a/app/views/saml_idp/idp/create.html.erb
+++ b/app/views/saml_idp/idp/create.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  </head>
+  <body onload="document.forms[0].submit();" style="visibility:hidden;">
+    <%= form_tag(saml_acs_url) do %>
+      <%= hidden_field_tag("SAMLResponse", @saml_response) %>
+      <%= hidden_field_tag("RelayState", params[:RelayState]) %>
+      <%= submit_tag "Submit" %>
+    <% end %>
+  </body>
+</html>


### PR DESCRIPTION
Create a view called create.html.erb to avoid erros such as the link below:
https://app.honeybadger.io/projects/43945/faults/82623598/01FYCQ3BX4NPJWQ3G0AY784H5H?page=0#notice-trace

It because when we call MFA view, the response action should use zendesk project directly ,but instead it calls this gem and return an error (MissingTemplate)

![image](https://user-images.githubusercontent.com/1241657/158904680-62f30495-d741-4cc8-8a53-d2481d462983.png)
